### PR TITLE
feat(WW-3531): add submit method to useForm composable

### DIFF
--- a/src/composables/useFormSubmission.js
+++ b/src/composables/useFormSubmission.js
@@ -1,27 +1,15 @@
 export function useFormSubmission({ emit, forceValidateAllFields }) {
     const handleSubmit = async event => {
-        console.log('[Form Container] handleSubmit called', {
-            event,
-            eventType: event?.type,
-            eventTarget: event?.target,
-        });
-        
         try {
-            console.log('[Form Container] Validating all fields...');
             const isValid = forceValidateAllFields();
-            console.log('[Form Container] Validation result:', isValid);
-            
             if (!isValid) {
-                console.log('[Form Container] Validation failed, emitting submit-validation-error');
                 emit('trigger-event', { name: 'submit-validation-error', event });
             } else {
-                console.log('[Form Container] Validation passed, emitting submit event');
                 emit('trigger-event', { name: 'submit', event });
             }
         } catch (error) {
-            console.error('[Form Container] Form submission error', error);
+            console.error('Form submission error', error);
         } finally {
-            console.log('[Form Container] handleSubmit completed');
         }
     };
 

--- a/src/composables/useFormSubmission.js
+++ b/src/composables/useFormSubmission.js
@@ -1,15 +1,27 @@
 export function useFormSubmission({ emit, forceValidateAllFields }) {
     const handleSubmit = async event => {
+        console.log('[Form Container] handleSubmit called', {
+            event,
+            eventType: event?.type,
+            eventTarget: event?.target,
+        });
+        
         try {
+            console.log('[Form Container] Validating all fields...');
             const isValid = forceValidateAllFields();
+            console.log('[Form Container] Validation result:', isValid);
+            
             if (!isValid) {
+                console.log('[Form Container] Validation failed, emitting submit-validation-error');
                 emit('trigger-event', { name: 'submit-validation-error', event });
             } else {
+                console.log('[Form Container] Validation passed, emitting submit event');
                 emit('trigger-event', { name: 'submit', event });
             }
         } catch (error) {
-            console.error('Form submission error', error);
+            console.error('[Form Container] Form submission error', error);
         } finally {
+            console.log('[Form Container] handleSubmit completed');
         }
     };
 

--- a/src/shared/useForm.js
+++ b/src/shared/useForm.js
@@ -60,7 +60,9 @@ export function useForm(
     const registerFormInput = inject('_wwForm:registerInput', () => {});
     const unregisterFormInput = inject('_wwForm:unregisterInput', () => {});
     const updateFormInput = inject('_wwForm:updateInput', () => {});
-    const submitForm = inject('_wwForm:submit', () => {});
+    const submitForm = inject('_wwForm:submit', () => {
+        console.log('[useForm] Default submitForm called (form not found)');
+    });
 
     const { uid } = elementState;
     const _fieldName = computed(() => fieldName?.value || elementState.name);

--- a/src/shared/useForm.js
+++ b/src/shared/useForm.js
@@ -52,6 +52,7 @@ export function useForm(
         validation,
         customValidation = shallowRef(false),
         required = shallowRef(false),
+        requiredValidation = null,
         initialValue = undefined,
     },
     { elementState, emit, sidepanelFormPath = 'form', setValue = null }
@@ -96,9 +97,11 @@ export function useForm(
     }
     const { resolveFormula } = wwLib.wwFormula.useFormula();
 
-    const computeValidation = (value, required, customValidation, validation) => {
+    const computeValidation = (value, required, customValidation, validation, requiredValidation) => {
         const validationResult = customValidation && validation ? resolveFormula(validation)?.value : true;
-        const hasValue = !isValueEmpty(value);
+        
+        // Use custom required validation if provided, otherwise use default isEmpty check
+        const hasValue = requiredValidation ? requiredValidation(value) : !isValueEmpty(value);
 
         // If not required, field is valid unless there's custom validation
         if (!required) {
@@ -110,7 +113,7 @@ export function useForm(
             return hasValue && validationResult;
         }
 
-        // If just required, check for value
+        // If just required, check for value using custom or default validation
         return hasValue;
     };
 
@@ -136,7 +139,7 @@ export function useForm(
     let isFirst = true;
     const computedValidation = computed(() => {
         // We have to compute the validation here, otherwise the reactivity will not work
-        const isValid = computeValidation(value.value, required.value, customValidation.value, validation.value);
+        const isValid = computeValidation(value.value, required.value, customValidation.value, validation.value, requiredValidation);
         if (isFirst) {
             isFirst = false;
             return null;
@@ -160,7 +163,7 @@ export function useForm(
         validationType => {
             if (validationType === 'change') {
                 updateInputValidity(
-                    computeValidation(value.value, required?.value, customValidation?.value, validation?.value)
+                    computeValidation(value.value, required?.value, customValidation?.value, validation?.value, requiredValidation)
                 );
             } else if (validationType === 'submit') {
                 updateInputValidity(true);
@@ -172,7 +175,7 @@ export function useForm(
     });
     function forceValidateField() {
         debouncedUpdateInputValidity.cancel();
-        const isValid = computeValidation(value.value, required?.value, customValidation?.value, validation?.value);
+        const isValid = computeValidation(value.value, required?.value, customValidation?.value, validation?.value, requiredValidation);
         updateInputValidity(isValid);
         return isValid;
     }

--- a/src/shared/useForm.js
+++ b/src/shared/useForm.js
@@ -60,9 +60,7 @@ export function useForm(
     const registerFormInput = inject('_wwForm:registerInput', () => {});
     const unregisterFormInput = inject('_wwForm:unregisterInput', () => {});
     const updateFormInput = inject('_wwForm:updateInput', () => {});
-    const submitForm = inject('_wwForm:submit', () => {
-        console.log('[useForm] Default submitForm called (form not found)');
-    });
+    const submitForm = inject('_wwForm:submit', () => {});
 
     const { uid } = elementState;
     const _fieldName = computed(() => fieldName?.value || elementState.name);

--- a/src/shared/useForm.js
+++ b/src/shared/useForm.js
@@ -60,6 +60,7 @@ export function useForm(
     const registerFormInput = inject('_wwForm:registerInput', () => {});
     const unregisterFormInput = inject('_wwForm:unregisterInput', () => {});
     const updateFormInput = inject('_wwForm:updateInput', () => {});
+    const submitForm = inject('_wwForm:submit', () => {});
 
     const { uid } = elementState;
     const _fieldName = computed(() => fieldName?.value || elementState.name);
@@ -217,6 +218,7 @@ export function useForm(
 
     return {
         selectForm,
+        submitForm,
     };
 }
 

--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -187,6 +187,7 @@ export default {
             validationType,
             debounceDelay,
         });
+        provide('_wwForm:submit', handleSubmit);
         provide('_wwForm:useForm', useForm);
         /* wwEditor:start */
         provide('_wwForm:selectForm', () => selectForm(props.wwElementState.uid, componentId.value));


### PR DESCRIPTION
## Summary
- Adds submitForm method to the useForm composable to enable programmatic form submission

## Changes
- Added injection of `_wwForm:submit` (handleSubmit method) in wwElement.vue
- Added submitForm to returned object in useForm composable

This allows child components using useForm to programmatically submit the parent form, which is needed for features like auto-submit in the OTP input component.