### PR TITLE
[WW-3871] Add detailed form validation debug logs

### DIFF
--- a/src/composables/useFormInputs.js
+++ b/src/composables/useFormInputs.js
@@ -52,14 +52,34 @@ export function useFormInputs({ updateInputValidity, removeInputValidity }) {
 
     function forceValidateAllFields() {
         const validityMap = {};
+        const invalidFields = [];
+        
         for (const [id, inputs] of Object.entries(inputsMap.value)) {
             for (const [name, input] of Object.entries(inputs)) {
                 if ('forceValidateField' in input) {
-                    validityMap[id + name] = input.forceValidateField();
+                    const isValid = input.forceValidateField();
+                    validityMap[id + name] = isValid;
+                    
+                    if (!isValid) {
+                        invalidFields.push({
+                            id: id,
+                            name: name,
+                            value: input.value,
+                            isValid: isValid,
+                            error: input.error || input.validationMessage || 'Validation failed'
+                        });
+                    }
                 }
             }
         }
-        return Object.values(validityMap).every(Boolean);
+        
+        const isValid = Object.values(validityMap).every(Boolean);
+        
+        return {
+            isValid,
+            invalidFields,
+            validityMap
+        };
     }
 
     function resetInputs(initialValues = {}) {

--- a/src/composables/useFormSubmission.js
+++ b/src/composables/useFormSubmission.js
@@ -1,15 +1,73 @@
-export function useFormSubmission({ emit, forceValidateAllFields }) {
+export function useFormSubmission({ emit, forceValidateAllFields, formInputs, formName }) {
     const handleSubmit = async event => {
         try {
-            const isValid = forceValidateAllFields();
-            if (!isValid) {
+            /* wwEditor:start */
+            wwLib.logStore.verbose('🚀 Form submission started', {
+                type: 'action',
+                preview: { form: formName?.value || 'Unnamed form' }
+            });
+            /* wwEditor:end */
+
+            const validationResult = forceValidateAllFields();
+            
+            if (!validationResult.isValid) {
+                const invalidFields = validationResult.invalidFields;
+                const fieldNames = invalidFields.map(f => f.name).join(', ');
+                
+                /* wwEditor:start */
+                wwLib.logStore.warning('❌ Form submission blocked - Validation errors detected', {
+                    type: 'action',
+                    preview: {
+                        form: formName?.value || 'Unnamed form',
+                        invalidFieldsCount: invalidFields.length,
+                        invalidFields: fieldNames,
+                        details: invalidFields
+                    }
+                });
+                /* wwEditor:end */
+
+                /* wwEditor:start */
+                wwLib.logStore.info('📋 Form validation details:', {
+                    type: 'action',
+                    preview: invalidFields.reduce((acc, field) => {
+                        acc[field.name] = {
+                            value: field.value,
+                            isValid: field.isValid,
+                            error: field.error || 'Validation failed'
+                        };
+                        return acc;
+                    }, {})
+                });
+                /* wwEditor:end */
+
                 emit('trigger-event', { name: 'submit-validation-error', event });
             } else {
+                const formData = Object.fromEntries(
+                    Object.entries(formInputs?.value || {}).map(([key, input]) => [key, input.value])
+                );
+
+                /* wwEditor:start */
+                wwLib.logStore.info('✅ Form submission successful - All validations passed', {
+                    type: 'action',
+                    preview: {
+                        form: formName?.value || 'Unnamed form',
+                        fieldsCount: Object.keys(formData).length,
+                        data: formData
+                    }
+                });
+                /* wwEditor:end */
+
                 emit('trigger-event', { name: 'submit', event });
             }
         } catch (error) {
+            /* wwEditor:start */
+            wwLib.logStore.error('💥 Form submission error', {
+                type: 'action',
+                error: error,
+                preview: { form: formName?.value || 'Unnamed form', error: error.message }
+            });
+            /* wwEditor:end */
             console.error('Form submission error', error);
-        } finally {
         }
     };
 

--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -105,6 +105,8 @@ export default {
             isValid,
             updateFormData,
             validationType,
+            formInputs,
+            formName,
         });
 
         function _setFormState(isSubmitting, isSubmitted) {


### PR DESCRIPTION
## Summary
- Enhanced form submission with detailed validation error logging
- Added comprehensive debug logs showing which fields block form submission
- Improved validation feedback for better debugging experience

## Changes Made
- Modified `forceValidateAllFields` to return detailed validation results including invalid fields info
- Enhanced `useFormSubmission` with rich logging using `wwLib.logStore`
- Added logs that appear in editor's log panel with proper filtering and search capabilities
- Logs include field names, values, validation states, and error messages

## Benefits
- **Immediate debugging**: Users can instantly see which fields are blocking form submission
- **Detailed context**: Each validation error shows field value and specific error message
- **Better support**: Support team can easily identify form validation issues
- **Enhanced UX**: Logs appear directly in WeWeb editor's log panel with timestamps and filtering