### PR TITLE
[WW-3647] Fix required validation for checkbox fields

### DIFF
--- a/src/shared/useForm.js
+++ b/src/shared/useForm.js
@@ -15,7 +15,7 @@ function isValueEmpty(value) {
     }
 
     if (typeof value === 'boolean') {
-        return false;
+        return value === false;
     }
 
     if (Array.isArray(value)) {


### PR DESCRIPTION
## Summary
- Fixed required validation for checkbox fields in forms
- Changed `isValueEmpty` function to treat `false` boolean values as empty
- Now required checkboxes must be checked (true) to pass validation

## Context
Previously, when a checkbox was marked as required, both `true` and `false` values were considered valid because the `isValueEmpty` function returned `false` for all boolean values. This meant that required checkboxes could not enforce that they must be checked.

This is particularly important for use cases like "I agree to terms and conditions" checkboxes where the form should not be valid unless the user explicitly checks the box.

## Changes
Modified the `isValueEmpty` function in `src/shared/useForm.js`:
```javascript
// Before
if (typeof value === 'boolean') {
    return false;
}

// After  
if (typeof value === 'boolean') {
    return value === false;
}
```

## Expected behavior
- `required: true` + checkbox `false` → `isValid: false` ❌
- `required: true` + checkbox `true` → `isValid: true` ✅
- `required: false` + checkbox `false` → `isValid: true` ✅
- `required: false` + checkbox `true` → `isValid: true` ✅